### PR TITLE
Simplified User Installation via Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,22 +69,6 @@ VirtualBox Installation:
 * https://www.virtualbox.org/wiki/Downloads
 * https://www.virtualbox.org/wiki/End-user_documentation
 
-Installing the Virtual Machine Image: Vagrant
-=============================================
-
-Once you've installed Vagrant and VirtualBox, you'll need to get an
-operating system image, or "box".  Please download one of the following
-large files:
-
-If you have a 64-bit laptop: http://files.vagrantup.com/precise64.box
-
-If you have a 32-bit laptop: http://files.vagrantup.com/precise32.box
-
-Then run the following command from the folder where you downloaded it:
-
-* 64-bit: vagrant box add precise precise64.box
-* 32-bit: vagrant box add precise precise32.box
-
 Installing Tutorial Exercises: Vagrant
 ======================================
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -6,8 +6,16 @@ Vagrant.configure("2") do |config|
   # options are documented and commented below. For a complete reference,
   # please see the online documentation at vagrantup.com.
 
-  # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "precise"
+  # Setup a 64 bit host by default
+  config.vm.box = "precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+
+  # If host is 32-bit use a 32-bit guest
+  if ENV["PROCESSOR_ARCHITECTURE"] == "x86"
+    puts "falling back to 32-bit guest architecture"
+    config.vm.box = "precise32"
+    config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+  end
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,


### PR DESCRIPTION
I have changed the vagrant file to automatically select the guest OS architecture based on the host architecture.  This eliminates the need for a user to manually download the vagrant box.  I also removed the part of the documentation that instructs the user to manually download the vbox.
